### PR TITLE
Fixed osis2mod tool link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install some python packages (requires python 3):
 
     pip install -r requirements.txt
 
-Install osis2mod tool that can be obtained from http://www.crosswire.org/wiki/DevTools:Modules
+Install osis2mod tool that can be obtained from https://wiki.crosswire.org/DevTools:Modules
 
 To convert ePub to SWORD module (compressed in a zip file), run command
 


### PR DESCRIPTION
The old link (http://www.crosswire.org/wiki/DevTools:Modules) for the osis2mod tool resulted in a 404 error:
![image](https://github.com/AndBible/sword_studybibles/assets/39864821/e9e2ca53-7223-4b3e-ba40-963da8251996)

Updated to working link (https://wiki.crosswire.org/DevTools:Modules).